### PR TITLE
Use startWithPort instead of the runWithPort

### DIFF
--- a/lib/apex/server.rb
+++ b/lib/apex/server.rb
@@ -50,7 +50,7 @@ module Apex
     end
 
     def start
-      server.runWithPort self.class.port, bonjourName: nil
+      server.startWithPort self.class.port, bonjourName: nil
     end
 
     # Class methods *************************


### PR DESCRIPTION
[runWithPort](http://cocoadocs.org/docsets/GCDWebServer/2.4/Classes/GCDWebServer.html#//api/name/runWithPort:bonjourName:) it's intended to be run with command line tools

Instead of runWithPort I've changed it to use [startWithPort](http://cocoadocs.org/docsets/GCDWebServer/2.4/Classes/GCDWebServer.html#//api/name/startWithPort:bonjourName:).
Also I get this error using runWithPort

```
from server.rb:8:in `on_launch'
    from delegate_interface.rb:5:in `applicationDidFinishLaunching:'
2014-06-16 22:31:50.697 ApexTest[15961:70b] *** Terminating app due to uncaught exception 'NoMethodError', reason: 'server.rb:53:in `start': undefined method `runWithPort' for #<GCDWebServer:0x8e2ee00> (NoMethodError)
    from server.rb:8:in `on_launch'
```
